### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "localtunnel",
   "description": "expose localhost to the world",
   "version": "1.5.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/shtylman/localtunnel.git"


### PR DESCRIPTION
To conform with NPM guidelines. Came across it causing issues when trying to import to [webjars](https://github.com/webjars/webjars).