### PR TITLE
Increase max event listeners to prevent premature memory-leak warnings

### DIFF
--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -73,6 +73,10 @@ Tunnel.prototype._init = function(cb) {
 Tunnel.prototype._establish = function(info) {
     var self = this;
     var opt = self._opt;
+    
+    // increase max event listeners so that localtunnel consumers don't get
+    // warning messages as soon as they setup even one listener. See #71
+    self.setMaxListeners(info.max_conn + (EventEmitter.defaultMaxListeners || 10));
 
     info.local_host = opt.local_host;
     info.local_port = opt.port;


### PR DESCRIPTION
See #71.