### PR TITLE
Implement short argv.

### DIFF
--- a/bin/client
+++ b/bin/client
@@ -2,35 +2,37 @@
 var lt_client = require('../client');
 var open_url = require('openurl');
 
-var argv = require('optimist')
-    .usage('Usage: $0 --port [num]')
-    .options('host', {
-        default: 'http://localtunnel.me',
-        describe: 'upstream server providing forwarding'
+var argv = require('yargs')
+    .usage('Usage: $0 --port [num] <options>')
+    .option('h', {
+        alias: 'host',
+        describe: 'Upstream server providing forwarding',
+        default: 'http://localtunnel.me'
     })
-    .options('subdomain', {
-        describe: 'request this subdomain'
+    .option('s', {
+        alias: 'subdomain',
+        describe: 'Request this subdomain'
     })
-    .options('local-host', {
-        describe: 'tunnel traffic to this host instead of localhost, override Host header to this host'
+    .option('l', {
+        alias: 'local-host',
+        describe: 'Tunnel traffic to this host instead of localhost, override Host header to this host'
     })
-    .options('version', {
-        describe: 'print version and exit'
-    })
-    .options('open', {
+    .options('o', {
+        alias: 'open',
         describe: 'opens url in your browser'
     })
-    .describe('port', 'internal http server port')
+    .option('p', {
+        alias: 'port',
+        describe: 'Internal http server port',
+    })
+    .require('port')
+    .help('help', 'Show this help and exit')
+    .version(require('../package').version)
     .argv;
 
-if (argv.version) {
-    console.log(require('../package.json').version);
-    process.exit(0);
-}
-
-if (argv.port == null) {
-    require('optimist').showHelp();
-    console.error('Missing required arguments: port');
+if (typeof argv.port !== 'number') {
+    require('yargs').showHelp();
+    console.error('port must be a number');
     process.exit(1);
 }
 
@@ -47,11 +49,11 @@ lt_client(opt.port, opt, function(err, tunnel) {
     }
 
     console.log('your url is: %s', tunnel.url);
-    
+
     if (argv.open) {
         open_url.open(tunnel.url);
     }
-    
+
     tunnel.on('error', function(err) {
         throw err;
     });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "request": "2.11.4",
-    "optimist": "0.3.4",
+    "yargs": "3.15.0",
     "debug": "0.7.4",
     "openurl": "1.1.0"
   },


### PR DESCRIPTION
[Optimist](https://github.com/substack/node-optimist) will be deprecated soon ( as the author stopped maintaining it)... recommending the use of either [minimist](https://github.com/substack/minimist) or [yargs](https://github.com/bcoe/yargs)

I've looked into both and I think that yargs is a better replacement... specially that it supports the aliases and it's syntax is similar to the optimist syntax...

now the options passed to the `lt` supports also the following shorhand args.
- `-p` alias `--port`
- `-h` alias `--host`
- `-s` alias `--subdomain`
- `-l` alias `--local-host`

please review the code (the PR code comments) before merging.