### PR TITLE
Keep sockets alive after connecting

### DIFF
--- a/lib/TunnelCluster.js
+++ b/lib/TunnelCluster.js
@@ -38,6 +38,8 @@ TunnelCluster.prototype.open = function() {
         port: remote_port
     });
 
+    remote.setKeepAlive(true);
+
     remote.on('error', function(err) {
         // emit connection refused errors immediately, because they
         // indicate that the tunnel can't be established.


### PR DESCRIPTION
calls `setKeepAlive(true)` on each of the connections so we don't get timed out. 

Fixes https://github.com/defunctzombie/localtunnel/issues/55
